### PR TITLE
v1.8.5

### DIFF
--- a/addons/Popochiu/Engine/Interfaces/ICharacter.gd
+++ b/addons/Popochiu/Engine/Interfaces/ICharacter.gd
@@ -87,9 +87,12 @@ func face_clicked(is_in_queue := true) -> void:
 
 # Checks if the character exists in the array of PopochiuCharacter instances.
 func is_valid_character(script_name: String) -> bool:
+	if script_name.to_lower() == 'player': return true
+	
 	for c in characters:
 		if (c as PopochiuCharacter).script_name.to_lower() == script_name.to_lower():
 			return true
+	
 	return false
 
 

--- a/addons/Popochiu/Engine/Objects/Clickable/PopochiuClickable.gd
+++ b/addons/Popochiu/Engine/Objects/Clickable/PopochiuClickable.gd
@@ -16,6 +16,8 @@ export(CURSOR_TYPE) var cursor
 export var always_on_top := false
 
 var room: Node2D = null setget set_room # It is a PopochiuRoom
+var times_clicked := 0
+var times_right_clicked := 0
 
 onready var _description_code := description
 
@@ -53,6 +55,7 @@ func _unhandled_input(event):
 		E.clicked = self
 		if event.is_action_pressed('popochiu-interact'):
 			get_tree().set_input_as_handled()
+			
 			if I.active:
 				on_item_used(I.active)
 			else:
@@ -60,12 +63,16 @@ func _unhandled_input(event):
 					action = 'Interacted with: %s' % description
 				})
 				on_interact()
+				
+				times_clicked += 1
 		elif event.is_action_pressed('popochiu-look'):
 			if not I.active:
 				E.add_history({
 					action = 'Looked at: %s' % description
 				})
 				on_look()
+				
+				times_right_clicked += 1
 
 
 func _process(delta):
@@ -137,6 +144,16 @@ func get_description() -> String:
 			description = name
 		return description
 	return E.get_text(description)
+
+
+func disable_input() -> void:
+	input_pickable = false
+	set_process_unhandled_input(false)
+
+
+func enable_input() -> void:
+	input_pickable = true
+	set_process_unhandled_input(false)
 
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ PRIVATE ░░░░

--- a/addons/Popochiu/Engine/Objects/Dialog/PopochiuDialogOption.gd
+++ b/addons/Popochiu/Engine/Objects/Dialog/PopochiuDialogOption.gd
@@ -1,4 +1,5 @@
 tool
+class_name PopochiuDialogOption
 extends Resource
 # Each option in a dialog.
 # ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓

--- a/addons/Popochiu/Engine/Objects/GraphicInterface/DialogText/DialogText.gd
+++ b/addons/Popochiu/Engine/Objects/GraphicInterface/DialogText/DialogText.gd
@@ -68,6 +68,9 @@ func play_text(props: Dictionary) -> void:
 		size.y = rt.get_content_height()
 	elif size.x < get_meta(DFLT_SIZE).x:
 		size.x = get_meta(DFLT_SIZE).x
+	
+	var character_count := lbl.get_total_character_count()
+	
 	lbl.free()
 	rt.free()
 	# ===================================== Calculate the width of the node ====
@@ -102,7 +105,7 @@ func play_text(props: Dictionary) -> void:
 		_tween.interpolate_property(
 			self, 'percent_visible',
 			0, 1,
-			_secs_per_character * get_total_character_count(),
+			_secs_per_character * character_count,
 			Tween.TRANS_LINEAR, Tween.EASE_IN_OUT
 		)
 		_tween.start()
@@ -130,7 +133,7 @@ func hide() -> void:
 	if modulate.a == 0.0: return
 	
 	_auto_continue = false
-	modulate.a = 0.5
+	modulate.a = 0.0
 	_is_waiting_input = false
 	
 	_tween.remove_all()

--- a/addons/Popochiu/Engine/Others/PopochiuSaveLoad.gd
+++ b/addons/Popochiu/Engine/Others/PopochiuSaveLoad.gd
@@ -122,7 +122,8 @@ func load_game(slot := 1) -> Dictionary:
 	
 	# Load main object states
 	for type in ['rooms', 'characters', 'inventory_items', 'dialogs']:
-		_load_state(type, loaded_data)
+		if loaded_data.has(type):
+			_load_state(type, loaded_data)
 	
 	# Load globals
 	if loaded_data.has('globals'):

--- a/addons/Popochiu/plugin.cfg
+++ b/addons/Popochiu/plugin.cfg
@@ -3,5 +3,5 @@
 name="Popochiu"
 description="[en] Graphic adventure engine for Godot. [es] Motor para crear juegos de Aventura gráfica (point n' click)."
 author="carenalga (@mapedorr) \\(|:3)/"
-version="1.8.4.a"
+version="1.8.5"
 script="PopochiuPlugin.gd"

--- a/popochiu/Characters/Goddiu/CharacterGoddiu.tscn
+++ b/popochiu/Characters/Goddiu/CharacterGoddiu.tscn
@@ -12,17 +12,17 @@ script_name = "Goddiu"
 description = "Goddiu"
 clickable = false
 cursor = 8
+is_player = true
+flips_when = 2
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
 polygon = PoolVector2Array( -9, -45, -1, -47, 17, -39, 22, -34, 23, -26, 19, -18, 10, -13, -4, -12, -17, -14, -22, -20, -22, -28 )
 
 [node name="BaselineHelper" type="Line2D" parent="."]
-visible = false
 points = PoolVector2Array( -10000, 0, 10000, 0 )
 width = 1.0
 
 [node name="WalkToHelper" type="Position2D" parent="."]
-visible = false
 __meta__ = {
 "_edit_group_": true
 }
@@ -40,5 +40,4 @@ texture = ExtResource( 2 )
 hframes = 6
 
 [node name="DialogPos" type="Position2D" parent="."]
-visible = false
 position = Vector2( -3, -48 )

--- a/popochiu/Characters/Popsy/CharacterPopsy.tscn
+++ b/popochiu/Characters/Popsy/CharacterPopsy.tscn
@@ -13,18 +13,15 @@ description = "Popsy"
 walk_to_point = Vector2( -34, -10 )
 cursor = 8
 text_color = Color( 0.768627, 0.423529, 0.443137, 1 )
-is_player = true
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="."]
 polygon = PoolVector2Array( 0, -28, 5, -28, 15, -23, 20, -19, 19, -12, 15, -6, 2, -5, -3, -1, -20, -5, -20, -10, -10, -24 )
 
 [node name="BaselineHelper" type="Line2D" parent="."]
-visible = false
 points = PoolVector2Array( -10000, 0, 10000, 0 )
 width = 1.0
 
 [node name="WalkToHelper" type="Position2D" parent="."]
-visible = false
 position = Vector2( -34, -10 )
 __meta__ = {
 "_edit_group_": true
@@ -43,5 +40,4 @@ texture = ExtResource( 2 )
 hframes = 10
 
 [node name="DialogPos" type="Position2D" parent="."]
-visible = false
 position = Vector2( 0, -33 )

--- a/popochiu/Dialogs/TestA/DialogTestA.gd
+++ b/popochiu/Dialogs/TestA/DialogTestA.gd
@@ -4,7 +4,16 @@ extends PopochiuDialog
 
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 func on_start() -> void:
-	yield(E.run([]), 'completed')
+	var op: PopochiuDialogOption = yield(D.show_inline_dialog([
+		'Hi',
+		'Oñiiii',
+		'Prrrrrrrr'
+	]), 'completed')
+	
+	yield(E.run([
+		'Player: ' + op.text,
+		'Popsy: ???'
+	]), 'completed')
 
 
 func option_selected(opt: PopochiuDialogOption) -> void:

--- a/popochiu/Rooms/101/Props/ToyCar/PropToyCar.gd
+++ b/popochiu/Rooms/101/Props/ToyCar/PropToyCar.gd
@@ -8,16 +8,12 @@ extends PopochiuProp
 # ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ VIRTUAL ░░░░
 # When the node is clicked
 func on_interact() -> void:
-#	Replace the call to .on_interact() to implement your code. This only makes
-#	the default behavior to happen.
-#	For example you can make the character walk to the Prop and then say
-#	something:
-#	E.run([
-#		C.walk_to_clicked(),
-#		C.face_clicked(),
-#		'Player: Not picking that up'
-#	])
-	.on_interact()
+	yield(E.run([
+		C.walk_to_clicked(),
+		C.face_clicked(),
+		"Player: I'm gonna take this with me",
+		I.add_item('ToyCar')
+	]), 'completed')
 
 
 # When the node is right clicked

--- a/popochiu/Rooms/101/Room101.gd
+++ b/popochiu/Rooms/101/Room101.gd
@@ -18,8 +18,10 @@ func on_room_entered() -> void:
 # What happens when the room changing transition finishes. At this point the room
 # is visible.
 func on_room_transition_finished() -> void:
-	# You can use yield(E.run([]), 'completed') to excecute a queue of instructions
-	pass
+	yield(E.run([
+		'Player: Here we go again',
+		'Popsy: What!?'
+	]), 'completed')
 
 
 # What happens before Popochiu unloads the room.

--- a/popochiu/Rooms/101/Room101.tscn
+++ b/popochiu/Rooms/101/Room101.tscn
@@ -74,6 +74,7 @@ description = "ToyCar"
 walk_to_point = Vector2( 24, 1 )
 cursor = 1
 texture = ExtResource( 10 )
+link_to_item = "ToyCar"
 
 [node name="InteractionPolygon" type="CollisionPolygon2D" parent="Props/Blanket/ToyCar"]
 polygon = PoolVector2Array( -9, 3, -8, -3, -1, -6, 6, -5, 9, 1, 6, 5 )

--- a/project.godot
+++ b/project.godot
@@ -29,6 +29,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/Popochiu/Engine/Objects/Dialog/PopochiuDialog.gd"
 }, {
+"base": "Resource",
+"class": "PopochiuDialogOption",
+"language": "GDScript",
+"path": "res://addons/Popochiu/Engine/Objects/Dialog/PopochiuDialogOption.gd"
+}, {
 "base": "PanelContainer",
 "class": "PopochiuGroup",
 "language": "GDScript",
@@ -94,6 +99,7 @@ _global_script_class_icons={
 "PopochiuCharacterData": "res://addons/Popochiu/icons/character.png",
 "PopochiuClickable": "",
 "PopochiuDialog": "res://addons/Popochiu/icons/dialog.png",
+"PopochiuDialogOption": "",
 "PopochiuGroup": "res://addons/Popochiu/Editor/MainDock/PopochiuGroup/popochiu_group.svg",
 "PopochiuHotspot": "res://addons/Popochiu/icons/hotspot.png",
 "PopochiuInventoryItem": "res://addons/Popochiu/icons/inventory_item.png",


### PR DESCRIPTION
# Fixes

- Loading saved games is working when the file doesn't has data for the main types: characters, inventory items or dialogs.
- Creating dialogue lines (for `E.run([])`) with wrong character names doesn't break the game.
- Creating dialogue lines with empty emotions doesn't break the game.
- **DialogText**'s ContinueIcon now is set to `modulate.a = 0.0` instead of 0.5 (this was for testing purpouses).
- **DialogText** animation speeds were not working because the method to count the total number of characters in the line was returning 0.
- Cursor doesn't show the clock icon when a **PopochiuDialog** is active.

# New things

- Added properties `times_clicked` and `times_right_clicked` to PopochiuClickable.
- Added methods `disable_input()` and `enable_input()` to PopochiuClickable.
- Created class for PopochiuDialogOption.